### PR TITLE
Make installation Just Work on 32-bit Ubuntu in Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The location to the Android SDK tools package to be installed.
 The location on disk where you'd like to SDK to be installed.
 
     android_sdk_dependency_packages:
-  		- "libncurses5:i386"
-		- "libstdc++6:i386"
-		- "zlib1g:i386"
+  		- "libncurses5"
+		- "libstdc++6"
+		- "zlib1g"
 		- "imagemagick"
 		- "expect"
 		- "gradle"
@@ -29,7 +29,6 @@ The location on disk where you'd like to SDK to be installed.
 		- "ccache"
 		- "autoconf"
 		- "automake"
-		- "ant"
 		- "ccache"
 		- "python-dev"
 		- "zlibc"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,9 @@ android_sdk_download_location: http://dl.google.com/android/android-sdk_r23.0.2-
 android_sdk_install_location: /opt
 
 android_sdk_dependency_packages:
-  - "libncurses5:i386"
-  - "libstdc++6:i386"
-  - "zlib1g:i386"
+  - "libncurses5"
+  - "libstdc++6"
+  - "zlib1g"
   - "imagemagick"
   - "expect"
   - "gradle"
@@ -19,5 +19,11 @@ android_sdk_dependency_packages:
   - "ccache"
   - "python-dev"
   - "zlibc"
+
+ubuntu_precise_dependency_packages:
+  - "libgd2-xpm"
+  - "libgphoto2-2"
+  - "libsane"
+  - "ia32-libs-multiarch"
 
 android_sdks_to_install: "build-tools-20.0.0,build-tools-19.1.0,platform-tools,tools,android-21,android-20,android-19,android-18,android-17,android-16,extra-android-support,extra-google-m2repository,extra-android-m2repository"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -6,12 +6,7 @@
 - name: Install ia32-libs on 12.04
   apt: pkg={{ item }} state=latest
   when: ansible_distribution_version == "12.04"
-  with_items:
-    - libgd2-xpm:i386
-    - libgphoto2-2:i386
-    - libsane:i386
-    - ia32-libs-multiarch
-    - ia32-libs
+  with_items: ubuntu_precise_dependency_packages
 
 - name: Install build dependencies
   apt: pkg={{ item }} state=latest


### PR DESCRIPTION
Edited the default package names so that dependency installation works on a Vagrant precise32 box. (http://files.vagrantup.com/precise32.box is the base image which couldn't find the `:i386`-suffixed packages)

Also factored out the dependency list to defaults, for consistency and ease of overriding it by other users. 
