### PR TITLE
Update default android_sdk to r24.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A recent version of Ubuntu.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    android_sdk_download_location: http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz
+    android_sdk_download_location: http://dl.google.com/android/android-sdk_r24.3.4-linux.tgz
 
 The location to the Android SDK tools package to be installed.
 
@@ -19,7 +19,7 @@ The location to the Android SDK tools package to be installed.
 The location on disk where you'd like to SDK to be installed.
 
     android_sdk_dependency_packages:
-  		- "libncurses5:i386"
+	  - "libncurses5:i386"
 		- "libstdc++6:i386"
 		- "zlib1g:i386"
 		- "imagemagick"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The location on disk where you'd like to SDK to be installed.
 
 A list of aptitude installable build dependency packages.
 
-    android_sdks_to_install: "build-tools-20.0.0,build-tools-19.1.0,platform-tools,tools,android-21,android-20,android-19,android-18,android-17,android-16,extra-android-support,extra-google-m2repository,extra-android-m2repository"
+    android_sdks_to_install: "build-tools-23,build-tools-22.0.1,build-tools-21.1.2,build-tools-20.0.0,build-tools-19.1.0,platform-tools,tools,android-23,android-22,android-21,android-20,android-19,android-18,android-17,android-16,extra-android-support,extra-google-m2repository,extra-android-m2repository"
 
 The actual Android SDK packages to install using the SDK manager.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for android-sdk
 
-android_sdk_download_location: http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz
+android_sdk_download_location: http://dl.google.com/android/android-sdk_r24.3.4-linux.tgz
 android_sdk_install_location: /opt
 
 android_sdk_dependency_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,4 @@ android_sdk_dependency_packages:
   - "python-dev"
   - "zlibc"
 
-android_sdks_to_install: "build-tools-20.0.0,build-tools-19.1.0,platform-tools,tools,android-21,android-20,android-19,android-18,android-17,android-16,extra-android-support,extra-google-m2repository,extra-android-m2repository"
+android_sdks_to_install: "build-tools-23,build-tools-22.0.1,build-tools-21.1.2,build-tools-20.0.0,build-tools-19.1.0,platform-tools,tools,android-23,android-22,android-21,android-20,android-19,android-18,android-17,android-16,extra-android-support,extra-google-m2repository,extra-android-m2repository"

--- a/tasks/sdktools.yml
+++ b/tasks/sdktools.yml
@@ -16,7 +16,7 @@
   file: path={{ android_sdk_install_location }}/android-sdk-linux recurse=yes mode=0755
 
 - name: Set system wide PATH to contain Android SDK tools
-  lineinfile: dest=/etc/environment regexp=^PATH line='PATH="/usr/local/sbin:/usr/local/bin:{{ android_sdk_install_location }}/android-sdk-linux/build-tools/20.0.0:{{ android_sdk_install_location }}/android-sdk-linux/tools/:{{ android_sdk_install_location }}/android-sdk-linux/build-tools/:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"'
+  lineinfile: dest=/etc/environment regexp=^PATH line='PATH="/usr/local/sbin:/usr/local/bin:{{ android_sdk_install_location }}/android-sdk-linux/build-tools/20.0.0:{{ android_sdk_install_location }}/android-sdk-linux/tools/:{{ android_sdk_install_location }}/android-sdk-linux/build-tools/:{{ android_sdk_install_location }}/android-sdk-linux/platform-tools/:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"'
 
 - name: Set system wide ANDROID_HOME environment variable
   lineinfile: dest=/etc/environment regexp=^ANDROID_HOME line='ANDROID_HOME="{{ android_sdk_install_location }}/android-sdk-linux/"'


### PR DESCRIPTION
Since new android sdk (r24.3.4) has been recently released, I've updated it to be default one. 
Additionally I've added all available (and previously missing) versions of build-tools Android SDKs to list with sdk components installed by default. 
Lastly I've added "platform-tools" folder to "Set system wide PATH to contain Android SDK tools" task in order to enable android adb in the console after installing Android SDK
