### PR TITLE
Fix 64

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,9 @@ android_sdk_download_location: http://dl.google.com/android/android-sdk_r24.4.1-
 android_sdk_install_location: /opt
 
 ubuntu_dependency_packages:
-  - "libncurses5"
-  - "libstdc++6"
-  - "zlib1g"
+  - "libncurses5:i386"
+  - "libstdc++6:i386"
+  - "zlib1g:i386"
   - "imagemagick"
   - "expect"
   - "gradle"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,7 +1,19 @@
 ---
-- name: Enable i386 arch in aptitude
-  command: dpkg --add-architecture i386 && apt-get update
+
+- name: Check if i386 is enabled
+  shell: dpkg --print-foreign-architectures | grep i386
+  register: result_i386_check
+  changed_when: result_i386_check.rc == 1
+  failed_when: result_i386_check.rc > 1
   when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version == "14.04"
+
+- name: Enable i386 arch in aptitude
+  command: dpkg --add-architecture i386
+  when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version == "14.04" and result_i386_check.rc == 1
+
+- name: Ensure apt cache is up to date
+  apt: update_cache=yes
+  when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and result_i386_check.rc == 1
 
 - name: Install ia32-libs on Ubuntu 12.04
   apt: pkg={{ item }} state=latest

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable i386 arch in aptitude
-  command: dpkg --add-architecture i386
+  command: dpkg --add-architecture i386 && apt-get update
   when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version == "14.04"
 
 - name: Install ia32-libs on Ubuntu 12.04


### PR DESCRIPTION
Looking at the issues page, it looks like you've gone back and forth on this a few times.

This fixed things on my ec2 instance

```
root $ uname -a
Linux ip-172-30-1-102 3.13.0-48-generic #80-Ubuntu SMP Thu Mar 12 11:16:15 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
root $ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.2 LTS
Release:        14.04
Codename:       trusty
```
