### PR TITLE
Supports versions of Ubuntu greater than 14.04

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -5,11 +5,11 @@
   register: result_i386_check
   changed_when: result_i386_check.rc == 1
   failed_when: result_i386_check.rc > 1
-  when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version == "14.04"
+  when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version >= "14.04"
 
 - name: Enable i386 arch in aptitude
   command: dpkg --add-architecture i386
-  when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version == "14.04" and result_i386_check.rc == 1
+  when: (ansible_distribution == "Ubuntu" or ansible_distribution == "Linuxmint") and ansible_distribution_version >= "14.04" and result_i386_check.rc == 1
 
 - name: Ensure apt cache is up to date
   apt: update_cache=yes


### PR DESCRIPTION
The task checking for i386 foreign architectures and registering the
result should not be skipped, otherwise the subsequent conditional
checks will fail on an undefined variable.

Let's update the conditional logic to use '>=' rather than '==' when
comparing Ubuntu versions. Tested on Ubuntu 16.04 and seems to work OK.
